### PR TITLE
Fix bug on iOS with resuming music after previously blocked by audio from another app

### DIFF
--- a/cocos/audio/ios/CDAudioManager.m
+++ b/cocos/audio/ios/CDAudioManager.m
@@ -644,15 +644,17 @@ static BOOL configured = FALSE;
         case kAMRBStopPlay:
             
             for( CDLongAudioSource *audioSource in audioSourceChannels) {
-                if (audioSource.isPlaying) {
-                    audioSource->systemPaused = YES;
-                    audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;
-                    [audioSource pause];
-                } else {
-                    //Music is either paused or stopped, if it is paused it will be restarted
-                    //by OS so we will stop it.
-                    audioSource->systemPaused = NO;
-                    [audioSource stop];
+                if (!audioSystem->systemPaused) {
+                    if (audioSource.isPlaying) {
+                        audioSource->systemPaused = YES;
+                        audioSource->systemPauseLocation = audioSource.audioSourcePlayer.currentTime;
+                        [audioSource pause];
+                    } else {
+                        //Music is either paused or stopped, if it is paused it will be restarted
+                        //by OS so we will stop it.
+                        audioSource->systemPaused = NO;
+                        [audioSource stop];
+                    }
                 }
             }
             break;


### PR DESCRIPTION
In this situation:
1. Start game, music plays
2. Switch to Music app, game music paused, start other music
3. Switch to game, game music not resumed due to other music playing
4. Switch to Music app, stop other music
5. Switch back to game, game music should resume due to no other music playing

At step 5 the game music doesn't currently resume. This is because at step 4 when switching to the Music app, the game music gets re-paused (actually isPlaying is false, so systemPaused is set to NO, even though the music _is_ still paused). This causes the music to not be resumed at step 5.

This change fixes this, by skipping the pause logic if systemPaused is already true.

Note that this is dependent on https://github.com/cocos2d/cocos2d-x/pull/16178
